### PR TITLE
Allow path objects

### DIFF
--- a/polars_readstat/polars_readstat/__init__.py
+++ b/polars_readstat/polars_readstat/__init__.py
@@ -89,7 +89,7 @@ def scan_readstat(path: str | Path,
 
 
     if reader is None:
-        reader = ScanReadstat(path=str(path),
+        reader = ScanReadstat(path=path,
                             engine=engine,
                             threads=threads,
                             use_mmap=use_mmap)


### PR DESCRIPTION
I think i would be useful to allow a Path object to be used as the argument for path parameter. I currently errors in _validation_check because a Path object does not have a method endswith.With a Path object you can use .suffix to check if the file type is either ".sas7bdat", ".dta" or ".sav". Was not sure what kind of datatype PyPolarsReadstat excepts and to be safe it is casted to a string.